### PR TITLE
Add CI to build and deploy to GitHub Pages with PR previews

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Allow the action to push the built site to the gh-pages branch.
+permissions:
+  contents: write
+
+# Never let two production deploys race each other.
+concurrency:
+  group: gh-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          branch: gh-pages
+          clean: true
+          # Keep per-PR preview directories published by pr-preview.yml.
+          clean-exclude: |
+            pr-preview

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,59 @@
+name: PR preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+# One preview deploy per PR; newer pushes supersede in-flight ones.
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      # The build uses `--public-url ./`, so the relative asset URLs work
+      # unchanged when served from /pr-preview/pr-<n>/.
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1.8.1
+        with:
+          source-dir: dist
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: deploy
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove preview
+        uses: rossjrw/pr-preview-action@v1.8.1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove


### PR DESCRIPTION
## What

Replaces the manual `yarn deploy` (`git subtree push --prefix dist origin gh-pages`) with GitHub Actions, adapting the pattern from [pablo-mayrgundter/portal#19](https://github.com/pablo-mayrgundter/portal/pull/19) to this repo's single-app yarn/Parcel setup.

Two workflows:

- **`.github/workflows/pages.yml`** — on push to `main` (and `workflow_dispatch`), runs `yarn build` and publishes `dist/` to the `gh-pages` branch via `JamesIves/github-pages-deploy-action@v4`. Uses `clean-exclude: pr-preview` so production deploys never wipe the per-PR preview directories.
- **`.github/workflows/pr-preview.yml`** — on `pull_request`, builds and publishes each PR to `gh-pages` under `pr-preview/pr-<n>/` via `rossjrw/pr-preview-action@v1.8.1`, and removes that directory when the PR closes. The action comments the preview URL on the PR.

## Why

The live site (`bldrs-ai.github.io/conway-viewer-demo`) was last deployed 2025-11-14 and still served conway `v0.22.969` with the old Arty.stp STEP bug, because `gh-pages` only updated via a manual deploy that hadn't run since. `main` already has conway `v1.336.1071` (PRs #5/#6). **Merging this PR runs `pages.yml` and auto-publishes the current `main` build, bringing the live site up to date.**

## Adaptation notes vs. portal#19

- Single app, so no composite build action or `--base` path injection. The build already uses `--public-url ./` (relative asset URLs), so the same `dist/` works served from `/` or from a `/pr-preview/pr-<n>/` subfolder — no base-path handling needed.
- Uses `yarn install --frozen-lockfile` + `yarn build` (this repo is yarn/Parcel v2, not npm/Vite).
- Deploys to the `gh-pages` branch (the repo's existing Pages source), so no `configure-pages`/`upload-pages-artifact`.

## Verification

- Both workflow files validated as well-formed YAML.
- Confirmed `gh-pages` has no `CNAME`/custom-domain file, so `clean: true` is safe.
- Confirmed `main`'s `yarn.lock` satisfies `package.json` (incl. `process@^0.11.10`) so `yarn install --frozen-lockfile` will resolve in CI.
- This PR itself exercises `pr-preview.yml`, so the preview deploy runs on it.

## Follow-up (not in this PR)

The manual `deploy` script in `package.json` is now redundant; it can be removed or repointed in a later change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFghs8FhTCmUxEcachbfge)_